### PR TITLE
Improve V build system and fix multiple issues

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangBuildContext.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangBuildContext.kt
@@ -14,6 +14,7 @@ class VlangBuildContext(
     val parentId: Any,
 ) {
     lateinit var workingDirectory: Path
+    var outputDirectory: Path? = null
 
     @Volatile
     lateinit var processHandler: ProcessHandler

--- a/src/main/kotlin/io/vlang/ide/run/VlangRunConfiguration.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangRunConfiguration.kt
@@ -72,7 +72,8 @@ open class VlangRunConfiguration(project: Project, factory: ConfigurationFactory
             }
         }
 
-        if (opt.buildArguments.contains("-o") || opt.buildArguments.contains("-output")) {
+        val argsTokens = opt.buildArguments.split("\\s+".toRegex())
+        if (argsTokens.any { it == "-o" || it == "-output" }) {
             throw RuntimeConfigurationError("Output file is set in build arguments - please use 'Output file' field instead!", object : ConfigurationQuickFix {
                 override fun applyFix(dataContext: DataContext) {
                     val args = opt.buildArguments.split(" ")


### PR DESCRIPTION
## Summary

- **Fix false C gen error** when using `-show-c-output` flag - the informational banner was incorrectly detected as an error
- **Honor VFLAGS environment variable** - extract `-cc` compiler setting from VFLAGS and pass directly to V
- **Fix output file handling** - always pass `-o` with absolute path, fix directory build output paths
- **Clean up build artifacts** - remove `*.tmp.obj` and `*.ilk` files after successful builds
- **Detect compiler crashes** - show helpful message when V crashes with access violation
- **Add full IDE macro support** - support macros like `$FileDir$` in run configuration fields
- **Fix `-o` detection** - properly tokenize build arguments to detect `-o`/`-output` flags

## Test plan

- [ ] Build a V project with `-show-c-output` in build arguments - should not show false "C gen error"
- [ ] Set `VFLAGS=-cc clang` in environment and debug - should use clang instead of default msvc/gcc
- [ ] Build project and verify `*.tmp.obj` and `*.ilk` files are cleaned up
- [ ] Use IDE macros in output file path - should expand correctly

🤖 Generated with [Claude Code](https://claude.ai/code)