### PR TITLE
Explicitly pass VFLAGS from system environment to V compiler

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
@@ -100,6 +100,14 @@ class VlangBuildTaskRunner : ProjectTaskRunner() {
             .withParameters("-color")
             .withWorkDirectory(workingDir)
 
+        // Ensure VFLAGS from system environment is passed to V if not in run config
+        if (!options.envsMap.containsKey("VFLAGS")) {
+            val systemVflags = System.getenv("VFLAGS")
+            if (systemVflags != null) {
+                commandLine.withEnvironment("VFLAGS", systemVflags)
+            }
+        }
+
         if (options.production) {
             commandLine.withParameters("-prod")
         }


### PR DESCRIPTION
## Summary
Ensure VFLAGS environment variable is always passed to the V compiler process.

The `CONSOLE` parent environment type may not reliably pass environment variables to child processes on all platforms. This change explicitly passes VFLAGS from the system environment to V when it's not already set in the run configuration's environment variables.

This ensures V receives VFLAGS regardless of how the IDE was started or how environment inheritance works on the platform.

## Test plan
- [ ] Set VFLAGS in system user environment variables
- [ ] Start IDE and build a V project
- [ ] Verify V respects the VFLAGS settings

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #70