### PR TITLE
Always pass -o flag with absolute output file path

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
@@ -118,9 +118,12 @@ class VlangBuildTaskRunner : ProjectTaskRunner() {
             }
         }
 
-        if (!outputFileName.isEmpty()) {
-            commandLine.withParameters("-o", File(outputFileName).absolutePath)
+        val effectiveOutputFile = if (outputFileName.isNotEmpty()) {
+            File(outputFileName).absolutePath
+        } else {
+            File(binaryName(options)).absolutePath
         }
+        commandLine.withParameters("-o", effectiveOutputFile)
 
         val additionalArguments = ParametersListUtil.parse(options.buildArguments)
         commandLine.addParameters(additionalArguments)


### PR DESCRIPTION
## Summary
Ensure consistent output file location by always passing the `-o` flag to V.

Previously, the `-o` flag was only passed when `outputFileName` was explicitly set. When not set, V would determine the output location itself, which could lead to inconsistent output locations.

Now the plugin always passes `-o` with an absolute path:
- Uses the configured output file if set
- Computes the default output location using `binaryName()` otherwise

## Test plan
- [ ] Build a V project without specifying output file - verify output location is predictable
- [ ] Build with explicit output file - verify it's respected

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)