### PR TITLE
Fix binaryName() to return absolute path for directory builds

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangBuildTaskRunner.kt
@@ -160,7 +160,8 @@ class VlangBuildTaskRunner : ProjectTaskRunner() {
                     File(options.workingDir, execFile).normalize().toString()
                 }
             } else {
-                File(options.workingDir).resolve(File(options.directory)).normalize().name
+                val dirName = File(options.workingDir).resolve(File(options.directory)).normalize().name
+                File(options.workingDir, dirName).normalize().toString()
             }
             if (SystemInfo.isWindows) {
                 return "$name.exe"


### PR DESCRIPTION
## Summary
Fix `binaryName()` function to return the correct absolute path for directory-based builds.

Previously, when building a directory (not a single file), `binaryName()` was returning just the directory name instead of the full absolute path. This caused issues when computing the output file location.

**Before:** Returns `myproject` (just the name)
**After:** Returns `S:\path\to\myproject` (full absolute path)

## Test plan
- [ ] Create a run configuration with "Directory" run kind
- [ ] Build and verify the output file is placed in the correct location

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #69