### PR TITLE
Detect V compiler crashes and show helpful message

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangBuildAdapter.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangBuildAdapter.kt
@@ -81,6 +81,17 @@ class VlangBuildAdapter(
         isCanceled: Boolean,
         error: Throwable?,
     ) {
+        if (!isSuccess && !isCanceled && ctx.errors.get() == 0) {
+            val exitCode = event.exitCode
+            val message = if (exitCode == -1073741819 || exitCode == 139) {
+                "V compiler crashed (access violation, exit code $exitCode). This is a V compiler bug."
+            } else {
+                "V compiler exited with code $exitCode but produced no error output."
+            }
+            val crashEvent = OutputBuildEventImpl(ctx.buildId, message + "\n", true)
+            buildProgressListener.onEvent(ctx.buildId, crashEvent)
+        }
+
         val (status, result) = when {
             isCanceled -> "canceled" to SkippedResultImpl()
             isSuccess  -> "successful" to SuccessResultImpl()


### PR DESCRIPTION
## Summary
Show a helpful message when the V compiler crashes or exits unexpectedly.

When the V compiler fails with no error output, users are left confused about what went wrong. This change detects such cases and shows an informative message:

**For known crash exit codes** (-1073741819 on Windows, 139 on Linux - access violations):
> V compiler crashed (access violation, exit code -1073741819). This is a V compiler bug.

**For other unexpected failures:**
> V compiler exited with code X but produced no error output.

This helps users understand that the issue is likely a V compiler bug, not a problem with their code.

## Test plan
- [ ] Trigger a V compiler crash (e.g., with certain edge cases)
- [ ] Verify the helpful message is shown in the build output

🤖 Generated with [Claude Code](https://claude.ai/code)