### PR TITLE
Fix false 'Output file' error triggered by flags like -showcc

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangRunConfiguration.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangRunConfiguration.kt
@@ -72,7 +72,8 @@ open class VlangRunConfiguration(project: Project, factory: ConfigurationFactory
             }
         }
 
-        if (opt.buildArguments.contains("-o") || opt.buildArguments.contains("-output")) {
+        val buildArgs = opt.buildArguments.split("\\s+".toRegex())
+        if (buildArgs.any { it == "-o" || it == "-output" }) {
             throw RuntimeConfigurationError("Output file is set in build arguments - please use 'Output file' field instead!", object : ConfigurationQuickFix {
                 override fun applyFix(dataContext: DataContext) {
                     val args = opt.buildArguments.split(" ")


### PR DESCRIPTION
## Summary
- Fixed false positive "Output file is set in build arguments" error triggered by unrelated V compiler flags like `-showcc` and `-show-c-output`
- Changed validation from substring matching (`String.contains`) to exact token matching so only standalone `-o` / `-output` flags are caught

## Test plan
- [ ] Set build arguments to `-showcc` — verify no error is shown
- [ ] Set build arguments to `-show-c-output` — verify no error is shown
- [ ] Set build arguments to `-o myfile` — verify error IS shown and quick fix works
- [ ] Set build arguments to `-output myfile` — verify error IS shown and quick fix works
- [ ] Set build arguments to `-g -keepc -showcc` — verify no error is shown

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)