### PR TITLE
Fix doubled path when running V file with working directory

### DIFF
--- a/src/main/kotlin/io/vlang/ide/run/VlangRunConfigurationRunState.kt
+++ b/src/main/kotlin/io/vlang/ide/run/VlangRunConfigurationRunState.kt
@@ -48,7 +48,12 @@ class VlangRunConfigurationRunState(
                     }
                 } else {
                     val binName = VlangBuildTaskRunner.binaryName(options)
-                    File(workingDir, binName)
+                    val binFile = File(binName)
+                    if (binFile.isRooted) {
+                        binFile
+                    } else {
+                        File(workingDir, binName)
+                    }
                 }
                 if (!exe.exists()) {
                     throw IllegalStateException("Can't run ${exe.absolutePath}, file not found")


### PR DESCRIPTION
## Summary
- `binaryName()` already returns an absolute path when the source file is relative, but `VlangRunConfigurationRunState` unconditionally prepended `workingDir`, producing paths like `S:\dir\S:\dir\file.exe`
- Added `isRooted` check before joining with `workingDir`, matching the existing `outputFileName` logic

Closes #63

## Test plan
- [ ] Create a V file run configuration with a relative source file and working directory set
- [ ] Run with output file field empty — verify the exe path is correct (no doubling)
- [ ] Run with an absolute output file path — verify it still works
- [ ] Run with a relative output file path — verify it resolves against working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)