### PR TITLE
Fix incomplete renderer mark stripping for empty strings

### DIFF
--- a/src/main/kotlin/io/vlang/debugger/renderers/VlangValueRenderer.kt
+++ b/src/main/kotlin/io/vlang/debugger/renderers/VlangValueRenderer.kt
@@ -92,6 +92,10 @@ abstract class VlangValueRenderer {
             ValueRendererUtils.extractString(this)
                 .replace("${MARK_CHAR}S", "")
                 .replace("${MARK_CHAR}K", "")
+                .replace("${MARK_CHAR}N", "")
+                .replace("${MARK_CHAR}C", "")
+                .replace("${MARK_CHAR}V", "")
+                .replace("${MARK_CHAR}E", "")
 
         private const val MARK_CHAR = 0xFE.toChar()
     }


### PR DESCRIPTION
## Summary
- Fix `removeRendererMarks()` to strip all mark types (E, N, C, V) not just S and K
- Fixes empty strings displaying raw marks like `þSþE` in the debugger Variables tab

Closes #67

## Test plan
- [x] Build plugin: `./gradlew buildPlugin`
- [x] Manual test: debug a V program with an optional string field set to None, verify it displays `None` instead of `þSþE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)