### PR TITLE
Fix UpToDateStubIndexMismatch (stub version bump + remove unreliable block detection)

### DIFF
--- a/src/main/kotlin/io/vlang/lang/VlangFileElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/VlangFileElementType.kt
@@ -49,6 +49,6 @@ class VlangFileElementType : IStubFileElementType<VlangFileStub>("VLANG_FILE", V
 
     companion object {
         val INSTANCE = VlangFileElementType()
-        const val VERSION = 95
+        const val VERSION = 96
     }
 }

--- a/src/main/kotlin/io/vlang/lang/stubs/types/VlangLabelDefinitionStubElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/stubs/types/VlangLabelDefinitionStubElementType.kt
@@ -8,6 +8,8 @@ import io.vlang.lang.psi.impl.VlangLabelDefinitionImpl
 import io.vlang.lang.stubs.VlangLabelDefinitionStub
 
 class VlangLabelDefinitionStubElementType(name: String) : VlangNamedStubElementType<VlangLabelDefinitionStub, VlangLabelDefinition>(name) {
+    override fun shouldIndex() = false
+
     override fun createPsi(stub: VlangLabelDefinitionStub): VlangLabelDefinition {
         return VlangLabelDefinitionImpl(stub, this)
     }

--- a/src/main/kotlin/io/vlang/lang/stubs/types/VlangNamedStubElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/stubs/types/VlangNamedStubElementType.kt
@@ -49,7 +49,7 @@ abstract class VlangNamedStubElementType<S : VlangNamedStub<T>, T : VlangNamedEl
         }
     }
 
-    protected fun shouldIndex() = true
+    protected open fun shouldIndex() = true
 
     protected open fun getExtraIndexKeys() = emptyList<StubIndexKey<String, out VlangNamedElement>>()
 }

--- a/src/main/kotlin/io/vlang/lang/stubs/types/VlangStubElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/stubs/types/VlangStubElementType.kt
@@ -1,12 +1,9 @@
 package io.vlang.lang.stubs.types
 
-import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StubBase
-import com.intellij.psi.util.PsiTreeUtil
 import io.vlang.lang.VlangLanguage
-import io.vlang.lang.psi.VlangBlock
 import io.vlang.lang.psi.VlangCompositeElement
 
 abstract class VlangStubElementType<S : StubBase<T>, T : VlangCompositeElement>(debugName: String) :
@@ -15,12 +12,4 @@ abstract class VlangStubElementType<S : StubBase<T>, T : VlangCompositeElement>(
     override fun getExternalId() = "vlang." + super.toString()
 
     override fun indexStub(stub: S, sink: IndexSink) {}
-
-    override fun shouldCreateStub(node: ASTNode): Boolean {
-        return super.shouldCreateStub(node) && shouldCreateStubInBlock(node)
-    }
-
-    protected open fun shouldCreateStubInBlock(node: ASTNode): Boolean {
-        return PsiTreeUtil.getParentOfType(node.psi, VlangBlock::class.java) == null
-    }
 }

--- a/src/main/kotlin/io/vlang/lang/stubs/types/VlangVarDefinitionStubElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/stubs/types/VlangVarDefinitionStubElementType.kt
@@ -8,6 +8,8 @@ import io.vlang.lang.psi.impl.VlangVarDefinitionImpl
 import io.vlang.lang.stubs.VlangVarDefinitionStub
 
 class VlangVarDefinitionStubElementType(name: String) : VlangNamedStubElementType<VlangVarDefinitionStub, VlangVarDefinition>(name) {
+    override fun shouldIndex() = false
+
     override fun createPsi(stub: VlangVarDefinitionStub): VlangVarDefinition {
         return VlangVarDefinitionImpl(stub, this)
     }


### PR DESCRIPTION
Fixes #74

## Root Cause

Two compounding bugs caused `com.intellij.psi.stubs.UpToDateStubIndexMismatch: Stub count (9) doesn't match stubbed node length (201)`:

**1. Missing stub version bump after "Keywords as identifiers" (`446520a0`)**

That commit fixed the parser so V keywords like `select` can appear as method names. Before it, `pub fn (db DB) select(...)` (as in `vlib/db/sqlite/orm.v`) failed to parse because `select` is a keyword token — the parser's error recovery produced a broken PSI tree with only ~9 stubs indexed. After the commit the file parses correctly, producing a much larger stub tree. Because the stub `VERSION` was not bumped, IntelliJ considered the cached 9-stub index valid (same file timestamp) and crashed when reconciling against the 201-node PSI.

**2. `shouldCreateStubInBlock` used PSI traversal unreliable at reconciliation time**

```kotlin
// old code in VlangStubElementType
protected open fun shouldCreateStubInBlock(node: ASTNode): Boolean {
    return PsiTreeUtil.getParentOfType(node.psi, VlangBlock::class.java) == null
}
```

`node.psi` traverses the PSI parent chain, which may not be fully established when `FileTrees.reconcilePsi` calls `shouldCreateStub`. This caused the reconciler to expect a different stub count than what was actually indexed, a latent crash independent of the version issue.

## Changes

- **Remove `shouldCreateStubInBlock`** from `VlangStubElementType` — all stub-typed nodes now always produce stubs, making indexing and reconciliation consistent.
- **Bump `VERSION` 95 → 96** — forces re-indexing of all V files with the corrected parser.
- **`shouldIndex() = false`** in `VlangVarDefinitionStubElementType` and `VlangLabelDefinitionStubElementType` — local variables and goto labels (always inside function bodies) are excluded from the global `VlangNamesIndex` now that the block filter is gone.
- **Make `shouldIndex()` `open`** in `VlangNamedStubElementType` to allow the above overrides.

## Test

Opened `vlib/db/sqlite/orm.v` with the plugin loaded — no more `UpToDateStubIndexMismatch` exception. `VlangCircularImportInspection` runs cleanly on the file.