### PR TITLE
Fix vfmt error parser crash on Windows paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
+* text=auto eol=lf
+*.bat eol=crlf
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
 *.vsh linguist-language=V text=auto eol=lf
-*.kt text eol=lf
-*.kts text eol=lf
-*.gradle text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
 *.vsh linguist-language=V text=auto eol=lf
+*.kt text eol=lf
+*.kts text eol=lf
+*.gradle text eol=lf

--- a/src/main/kotlin/io/vlang/ide/injection/VlangRegexLanguageInjector.kt
+++ b/src/main/kotlin/io/vlang/ide/injection/VlangRegexLanguageInjector.kt
@@ -12,6 +12,14 @@ import io.vlang.utils.parentNth
 
 class VlangRegexLanguageInjector : LanguageInjector {
     override fun getLanguagesToInject(host: PsiLanguageInjectionHost, injectionPlacesRegistrar: InjectedLanguagePlaces) {
+        try {
+            doGetLanguagesToInject(host, injectionPlacesRegistrar)
+        } catch (_: Exception) {
+            // Stub index may be stale (e.g. file modified externally); skip injection rather than crashing.
+        }
+    }
+
+    private fun doGetLanguagesToInject(host: PsiLanguageInjectionHost, injectionPlacesRegistrar: InjectedLanguagePlaces) {
         if (host !is VlangStringLiteral) return
 
         // string with interpolation

--- a/src/main/kotlin/io/vlang/lang/formatter/VlangFormattingService.kt
+++ b/src/main/kotlin/io/vlang/lang/formatter/VlangFormattingService.kt
@@ -90,8 +90,10 @@ class VlangFormattingService : AsyncDocumentFormattingService() {
 
         val filenameAndLine = error.substring(0, errorIndex).trim()
         val fileParts = filenameAndLine.split(":")
-        val line = fileParts.getOrElse(1) { "-1" }.toIntOrNull() ?: -1
-        val column = fileParts.getOrElse(2) { "0" }.toIntOrNull() ?: 0
+        // Parse from the end to handle Windows drive-letter paths (e.g. "S:\path\file.v:10:5:")
+        // Parts from end: ["", col, line, ...path parts...]
+        val line = fileParts.getOrElse(fileParts.size - 3) { "0" }.toIntOrNull() ?: 0
+        val column = fileParts.getOrElse(fileParts.size - 2) { "0" }.toIntOrNull() ?: 0
         val firstNewLineIndex = error.indexOf("\n")
         val errorText = error.substring(errorIndex + 6, firstNewLineIndex)
 
@@ -104,7 +106,7 @@ class VlangFormattingService : AsyncDocumentFormattingService() {
 
         val file = context.containingFile
         val document = PsiDocumentManager.getInstance(context.project).getDocument(file)
-        val lineOffset = document?.getLineStartOffset(line - 1) ?: -1
+        val lineOffset = if (line > 0) document?.getLineStartOffset(line - 1) ?: 0 else 0
         val offset = lineOffset + column
 
         var internalVfmtIndex = error.indexOf("Internal vfmt")

--- a/src/main/kotlin/io/vlang/lang/psi/VlangFile.kt
+++ b/src/main/kotlin/io/vlang/lang/psi/VlangFile.kt
@@ -271,7 +271,7 @@ open class VlangFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider,
     fun getGlobalVariables(): List<VlangGlobalVariableDefinition> {
         val value = {
             if (stub != null) {
-                getChildrenByType(stub!!, VlangTypes.GLOBAL_VARIABLE_DEFINITION) { arrayOfNulls<VlangGlobalVariableDefinition>(it) }
+                getChildrenByType(stub!!, VlangTypes.GLOBAL_VARIABLE_DEFINITION) { arrayOfNulls<VlangGlobalVariableDefinition>(it) }.filterNotNull()
             } else {
                 val decls = children.filterIsInstance<VlangGlobalVariableDeclaration>()
                 decls.flatMap { it.globalVariableDefinitionList }
@@ -286,7 +286,7 @@ open class VlangFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider,
     fun getConstants(): List<VlangConstDefinition> {
         val value = {
             if (stub != null) {
-                getChildrenByType(stub!!, VlangTypes.CONST_DEFINITION) { arrayOfNulls<VlangConstDefinition>(it) }
+                getChildrenByType(stub!!, VlangTypes.CONST_DEFINITION) { arrayOfNulls<VlangConstDefinition>(it) }.filterNotNull()
             } else {
                 val decls = children.filterIsInstance<VlangConstDeclaration>()
                 decls.flatMap { it.constDefinitionList }


### PR DESCRIPTION
## Summary

- Fixes \`IndexOutOfBoundsException: Wrong line: -2\` crash when vfmt reports a formatting error on a file with a Windows drive-letter path (e.g. \`S:\path\file.v\`)
- Splitting the error prefix on \`:\` at fixed index \`[1]\` gave the path string instead of the line number on Windows; now parses line/column from the end of the split array, which works on both Unix and Windows paths
- Adds a bounds guard before \`getLineStartOffset\` to prevent crashes if line parsing still yields an invalid value
- Applies reviewer suggestion: replaces per-extension \`eol=lf\` rules in \`.gitattributes\` with a blanket \`* text=auto eol=lf\` and explicit \`*.bat eol=crlf\` exception
- Fixes \`StubTreeAndIndexUnmatchCoarseException\` crash in \`VlangRegexLanguageInjector\` when a vlib file is modified externally (e.g. via \`v up\`) and the stub index is temporarily stale; injection is now skipped gracefully until the index self-heals on the next VFS refresh
- Fixes \`NullPointerException\` in \`VlangFile.getConstants\` and \`VlangFile.getGlobalVariables\`: \`getChildrenByType\` allocates with \`arrayOfNulls\`, so stub slots that resolve to null ended up in the returned list; adds the missing \`filterNotNull()\` that \`getTypes()\` already had

Closes #76