### PR TITLE
Fix conditional breakpoints with string comparisons. Closes #78

### DIFF
--- a/src/main/kotlin/io/vlang/debugger/VlangLldbDriver.kt
+++ b/src/main/kotlin/io/vlang/debugger/VlangLldbDriver.kt
@@ -1,6 +1,7 @@
 package io.vlang.debugger
 
 import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.jetbrains.cidr.ArchitectureType
@@ -31,22 +32,56 @@ class VlangLldbDriver(
 
     /**
      * Transpiles a V breakpoint condition expression to C syntax for LLDB.
-     * If transpilation fails, returns the original expression to allow simple C-compatible conditions to work.
+     * Tries regex-based pattern matching first for known patterns (string
+     * comparisons), then falls back to PSI-based transpilation.
+     * Regex-first avoids PSI resolution failures for local variables that
+     * can't be resolved in the file-level PSI context.
      */
     private fun transpileCondition(condition: String, filePath: String, line: Int): String {
+        // Fast path: handle known patterns directly without PSI resolution
+        val fast = fallbackTranspile(condition)
+        if (fast != condition) return fast
+
+        // Slow path: full PSI-based transpilation for complex expressions
         val proj = project ?: return condition
-        val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return condition
+        val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath)
+            ?: return condition
 
         return try {
             val transpiler = VlangExpressionTranspiler()
             runReadAction {
-                // Use line number to estimate offset (approximate)
-                transpiler.transpile(proj, virtualFile, null, condition)
+                val document = FileDocumentManager.getInstance().getDocument(virtualFile)
+                val offset = document?.let {
+                    val zeroBasedLine = (line - 1).coerceIn(0, it.lineCount - 1)
+                    it.getLineStartOffset(zeroBasedLine)
+                }
+                transpiler.transpile(proj, virtualFile, offset, condition)
             }
         } catch (_: Exception) {
-            // If transpilation fails, return original condition
-            // This allows simple C-compatible conditions like "i == 5" to work
             condition
         }
+    }
+
+    /**
+     * Regex-based fallback for when PSI transpilation fails (e.g. variable
+     * can't be resolved in the file's PSI context).  Handles the most common
+     * breakpoint condition pattern: string field compared to a literal.
+     *
+     * `job.part_num == '2601-3255'`  →  `strcmp((char*)(job.part_num).str, "2601-3255") == 0`
+     */
+    private fun fallbackTranspile(condition: String): String {
+        STRING_COMPARE_PATTERN.matchEntire(condition.trim())?.let { m ->
+            val lhs = m.groupValues[1].trim()
+            val op = m.groupValues[2]
+            val strValue = m.groupValues[3]
+            return """strcmp((char*)($lhs).str, "$strValue") $op 0"""
+        }
+        return condition
+    }
+
+    companion object {
+        // Matches:  expr == 'str'  |  expr != "str"
+        private val STRING_COMPARE_PATTERN =
+            """(.+?)\s*(==|!=)\s*['"](.+?)['"]""".toRegex()
     }
 }

--- a/src/main/kotlin/io/vlang/debugger/v2c/VlangExpressionEvaluator.kt
+++ b/src/main/kotlin/io/vlang/debugger/v2c/VlangExpressionEvaluator.kt
@@ -148,6 +148,36 @@ class VlangExpressionEvaluator : VlangVisitor() {
         append(")")
     }
 
+    override fun visitBinaryExpr(expr: VlangBinaryExpr) {
+        val left = expr.left
+        val right = expr.right ?: return
+        val op = expr.operator?.text ?: return
+
+        val leftType = left.getType(null)
+
+        // V strings are structs in C; == and != cannot use C's == on structs.
+        // string__eq() is typically static inline and unavailable to LLDB's expression
+        // evaluator, so use strcmp() on the raw .str field instead.
+        if (leftType is VlangStringTypeEx && (op == "==" || op == "!=")) {
+            append("strcmp((char*)(")
+            left.accept(this)
+            append(").str, ")
+            if (right is VlangStringLiteral) {
+                // Emit a plain C string literal — no need for a V string struct
+                append("\"${right.contents}\"")
+            } else {
+                append("(char*)(")
+                right.accept(this)
+                append(").str")
+            }
+            append(") $op 0")
+        } else {
+            left.accept(this)
+            append(" $op ")
+            right.accept(this)
+        }
+    }
+
     override fun visitElement(element: VlangElement) {
         element.value?.accept(this)
     }


### PR DESCRIPTION
## Summary
- Conditional breakpoints using string equality (e.g. `job.part_num == '2601-3255'`) always fired regardless of condition value
- Added regex-based fast path in `VlangLldbDriver` that detects `expr == 'literal'` patterns and emits `strcmp()` on the raw `.str` field — bypasses PSI resolution entirely
- Added `visitBinaryExpr` to `VlangExpressionEvaluator` with `strcmp()`-based string comparison for the PSI transpilation path
- Fixed `transpileCondition` to compute proper file offset from breakpoint line number

## Root cause
Two issues combined: `VlangExpressionEvaluator` had no `visitBinaryExpr` override (comparison operators were silently dropped), and the PSI transpiler returned the original V expression without throwing when it couldn't resolve local variables, so the fallback was never reached. LLDB received raw V syntax it couldn't evaluate.

## Test plan
- [ ] Set conditional breakpoint with string comparison: `job.part_num == '2601-3255'`
- [ ] Verify breakpoint only stops when condition is true
- [ ] Verify numeric conditions like `i == 5` still work
- [ ] Verify unconditional breakpoints are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)