### PR TITLE
Suppress duplicate features when a V language server (LSP4IJ) is active

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,13 +23,13 @@ golandVersion = LATEST-EAP-SNAPSHOT
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions/stable
 # https://plugins.jetbrains.com/plugin/7793-markdown/versions/stable
-ideaPlugins = com.intellij.nativeDebug:252.23892.346
+ideaPlugins = com.intellij.nativeDebug:252.23892.346, com.redhat.devtools.lsp4ij:0.19.2
 ideaBundledPlugins = com.intellij.java, org.intellij.plugins.markdown
 ideaCommunityPlugins =
 ideaCommunityBundledPlugins = com.intellij.java
-clionPlugins = com.intellij.nativeDebug:252.23892.346
+clionPlugins = com.intellij.nativeDebug:252.23892.346, com.redhat.devtools.lsp4ij:0.19.2
 clionBundledPlugins = com.intellij.cidr.base, com.intellij.clion
-golandPlugins = com.intellij.nativeDebug:252.23892.346
+golandPlugins = com.intellij.nativeDebug:252.23892.346, com.redhat.devtools.lsp4ij:0.19.2
 golandBundledPlugins =
 
 # Java language level used to compile sources and to generate the files for - Java 21 is required since 2024.2

--- a/src/main/kotlin/io/vlang/configurations/VlangLspSettingsConfigurable.kt
+++ b/src/main/kotlin/io/vlang/configurations/VlangLspSettingsConfigurable.kt
@@ -1,0 +1,89 @@
+package io.vlang.configurations
+
+import com.intellij.openapi.observable.properties.PropertyGraph
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+import io.vlang.lsp.VlangLspSettings
+
+class VlangLspSettingsConfigurable : Configurable {
+    private val mainPanel: DialogPanel
+    private val graph = PropertyGraph()
+
+    private val suppressWhenLspActive = graph.property(true)
+    private val suppressInlayHints = graph.property(true)
+    private val suppressSemanticHighlighting = graph.property(true)
+    private val suppressDiagnostics = graph.property(true)
+    private val suppressCompletion = graph.property(false)
+
+    init {
+        mainPanel = panel {
+            row {
+                checkBox("Suppress duplicate features when a V language server is active")
+                    .bindSelected(suppressWhenLspActive)
+                    .comment(
+                        "When a V language server is running via LSP4IJ, the native plugin can suppress " +
+                        "features that the server already provides to avoid duplicates."
+                    )
+            }
+            indent {
+                row {
+                    checkBox("Suppress inlay hints")
+                        .bindSelected(suppressInlayHints)
+                        .enabledIf(suppressWhenLspActive)
+                }
+                row {
+                    checkBox("Suppress semantic highlighting")
+                        .bindSelected(suppressSemanticHighlighting)
+                        .enabledIf(suppressWhenLspActive)
+                }
+                row {
+                    checkBox("Suppress diagnostics")
+                        .bindSelected(suppressDiagnostics)
+                        .enabledIf(suppressWhenLspActive)
+                }
+                row {
+                    checkBox("Suppress code completion")
+                        .bindSelected(suppressCompletion)
+                        .enabledIf(suppressWhenLspActive)
+                        .comment("Off by default — native completions may complement the language server.")
+                }
+            }
+        }
+    }
+
+    override fun getDisplayName() = "Language Server (LSP4IJ)"
+    override fun getPreferredFocusedComponent() = mainPanel
+    override fun createComponent() = mainPanel
+
+    override fun isModified(): Boolean {
+        mainPanel.apply()
+        val s = VlangLspSettings.getInstance()
+        return suppressWhenLspActive.get() != s.suppressWhenLspActive ||
+                suppressInlayHints.get() != s.suppressInlayHints ||
+                suppressSemanticHighlighting.get() != s.suppressSemanticHighlighting ||
+                suppressDiagnostics.get() != s.suppressDiagnostics ||
+                suppressCompletion.get() != s.suppressCompletion
+    }
+
+    override fun apply() {
+        mainPanel.apply()
+        val s = VlangLspSettings.getInstance()
+        s.suppressWhenLspActive = suppressWhenLspActive.get()
+        s.suppressInlayHints = suppressInlayHints.get()
+        s.suppressSemanticHighlighting = suppressSemanticHighlighting.get()
+        s.suppressDiagnostics = suppressDiagnostics.get()
+        s.suppressCompletion = suppressCompletion.get()
+    }
+
+    override fun reset() {
+        val s = VlangLspSettings.getInstance()
+        suppressWhenLspActive.set(s.suppressWhenLspActive)
+        suppressInlayHints.set(s.suppressInlayHints)
+        suppressSemanticHighlighting.set(s.suppressSemanticHighlighting)
+        suppressDiagnostics.set(s.suppressDiagnostics)
+        suppressCompletion.set(s.suppressCompletion)
+        mainPanel.reset()
+    }
+}

--- a/src/main/kotlin/io/vlang/ide/hints/VlangChainMethodInlayHintsProvider.kt
+++ b/src/main/kotlin/io/vlang/ide/hints/VlangChainMethodInlayHintsProvider.kt
@@ -19,6 +19,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.endOffset
 import io.vlang.lang.VlangLanguage
 import io.vlang.lang.psi.VlangCallExpr
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 import io.vlang.utils.childOfType
 import io.vlang.utils.parentNth
 import javax.swing.JPanel
@@ -50,6 +52,10 @@ class VlangChainMethodInlayHintsProvider : InlayHintsProvider<VlangChainMethodIn
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 // If the indexing process is in progress.
                 if (file.project.service<DumbService>().isDumb) return false
+                val vFile = file.virtualFile ?: return false
+                val lspSettings = VlangLspSettings.getInstance()
+                if (lspSettings.suppressWhenLspActive && lspSettings.suppressInlayHints
+                    && file.project.service<VlangLspBridge>().isActiveForFile(vFile, file.project)) return false
                 if (element !is VlangCallExpr) return true
                 if (element.expression?.childOfType<VlangCallExpr>() != null) return true
 

--- a/src/main/kotlin/io/vlang/ide/hints/VlangInlayHintsCollector.kt
+++ b/src/main/kotlin/io/vlang/ide/hints/VlangInlayHintsCollector.kt
@@ -17,6 +17,8 @@ import com.intellij.psi.util.startOffset
 import io.vlang.ide.codeInsight.VlangCodeInsightUtil
 import io.vlang.lang.VlangLanguage
 import io.vlang.lang.psi.*
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 import io.vlang.lang.psi.types.VlangResultTypeEx
 import io.vlang.lang.psi.types.VlangUnknownTypeEx
 import io.vlang.utils.line
@@ -34,6 +36,10 @@ class VlangInlayHintsCollector(
     override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
         // If the indexing process is in progress.
         if (file.project.service<DumbService>().isDumb) return true
+        val vFile = file.virtualFile ?: return true
+        val lspSettings = VlangLspSettings.getInstance()
+        if (lspSettings.suppressWhenLspActive && lspSettings.suppressInlayHints
+            && file.project.service<VlangLspBridge>().isActiveForFile(vFile, file.project)) return true
 
         when {
             element is VlangRangeExpr && settings.showForRanges          -> handleRange(element)
@@ -51,6 +57,10 @@ class VlangInlayHintsCollector(
         val type = element.getTypeInner(null) ?: return
         if (type is VlangUnknownTypeEx) {
             // no need show hint if type is unknown
+            return
+        }
+        if (UNKNOWN_WORD_REGEX.containsMatchIn(type.readableName(element))) {
+            // suppress hint if the type name literally contains "unknown" (e.g. a V type named `unknown`)
             return
         }
 
@@ -139,6 +149,10 @@ class VlangInlayHintsCollector(
         val type = element.getTypeInner(null) ?: return
         if (type is VlangUnknownTypeEx) {
             // no need show hint if type is unknown
+            return
+        }
+        if (UNKNOWN_WORD_REGEX.containsMatchIn(type.readableName(element))) {
+            // suppress hint if the type name literally contains "unknown" (e.g. a V type named `unknown`)
             return
         }
 
@@ -235,4 +249,10 @@ class VlangInlayHintsCollector(
             )
         }, left = 1
     )
+
+    companion object {
+        // Matches the word "unknown" as a standalone token within a V type name,
+        // e.g. "unknown" or "map[string]unknown" but not "UnknownCDeclaration".
+        private val UNKNOWN_WORD_REGEX = Regex("""\bunknown\b""")
+    }
 }

--- a/src/main/kotlin/io/vlang/ide/hints/VlangParameterNameHintsProvider.kt
+++ b/src/main/kotlin/io/vlang/ide/hints/VlangParameterNameHintsProvider.kt
@@ -3,11 +3,14 @@ package io.vlang.ide.hints
 import com.intellij.codeInsight.hints.HintInfo
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.startOffset
 import io.vlang.lang.VlangLanguage
 import io.vlang.lang.psi.*
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 import kotlin.math.min
 
 @Suppress("UnstableApiUsage")
@@ -28,6 +31,10 @@ class VlangParameterNameHintsProvider : InlayParameterHintsProvider {
 
     override fun getParameterHints(element: PsiElement, file: PsiFile): MutableList<InlayInfo> {
         if (element !is VlangCallExpr) return mutableListOf()
+        val vFile = file.virtualFile ?: return mutableListOf()
+        val lspSettings = VlangLspSettings.getInstance()
+        if (lspSettings.suppressWhenLspActive && lspSettings.suppressInlayHints
+            && file.project.service<VlangLspBridge>().isActiveForFile(vFile, file.project)) return mutableListOf()
         return handleCallExpr(element)
     }
 

--- a/src/main/kotlin/io/vlang/lang/annotator/VlangAnnotator.kt
+++ b/src/main/kotlin/io/vlang/lang/annotator/VlangAnnotator.kt
@@ -4,11 +4,14 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.elementType
 import io.vlang.ide.codeInsight.VlangDeprecationsUtil
 import io.vlang.ide.colors.VlangColor
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 import io.vlang.lang.VlangTypes
 import io.vlang.lang.completion.VlangCompletionUtil
 import io.vlang.lang.psi.*
@@ -19,6 +22,10 @@ import io.vlang.lang.psi.types.VlangPrimitiveTypes
 class VlangAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
+        val vFile = element.containingFile?.virtualFile ?: return
+        val lspSettings = VlangLspSettings.getInstance()
+        if (lspSettings.suppressWhenLspActive && lspSettings.suppressSemanticHighlighting
+            && element.project.service<VlangLspBridge>().isActiveForFile(vFile, element.project)) return
 
         val color = highlightLeaf(element, holder) ?: return
         holder.newSilentAnnotation(HighlightSeverity.INFORMATION).textAttributes(color.textAttributesKey).create()

--- a/src/main/kotlin/io/vlang/lang/annotator/VlangCheckerAnnotator.kt
+++ b/src/main/kotlin/io/vlang/lang/annotator/VlangCheckerAnnotator.kt
@@ -2,14 +2,21 @@ package io.vlang.lang.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import io.vlang.lang.annotator.checkers.VlangCommonProblemsChecker
 import io.vlang.lang.annotator.checkers.VlangOptionResultProblemsChecker
 import io.vlang.lang.psi.VlangVisitor
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 
 class VlangCheckerAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (!element.isValid) return
+        val vFile = element.containingFile?.virtualFile ?: return
+        val lspSettings = VlangLspSettings.getInstance()
+        if (lspSettings.suppressWhenLspActive && lspSettings.suppressDiagnostics
+            && element.project.service<VlangLspBridge>().isActiveForFile(vFile, element.project)) return
 
         val visitors = getCheckerVisitors(holder)
 

--- a/src/main/kotlin/io/vlang/lang/completion/contributors/VlangCompletionContributor.kt
+++ b/src/main/kotlin/io/vlang/lang/completion/contributors/VlangCompletionContributor.kt
@@ -4,6 +4,9 @@ import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.components.service
+import io.vlang.lsp.VlangLspBridge
+import io.vlang.lsp.VlangLspSettings
 import io.vlang.lang.completion.VlangCompletionPatterns.cachedReferenceExpression
 import io.vlang.lang.completion.VlangCompletionPatterns.insideStatementWithLabel
 import io.vlang.lang.completion.VlangCompletionPatterns.insideStruct
@@ -40,6 +43,12 @@ class VlangCompletionContributor : CompletionContributor() {
     }
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        val vFile = parameters.originalFile.virtualFile ?: return
+        val project = parameters.position.project
+        val lspSettings = VlangLspSettings.getInstance()
+        if (lspSettings.suppressWhenLspActive && lspSettings.suppressCompletion
+            && project.service<VlangLspBridge>().isActiveForFile(vFile, project)) return
+
         super.fillCompletionVariants(parameters, withVlangSorter(parameters, result))
     }
 }

--- a/src/main/kotlin/io/vlang/lsp/Lsp4ijBridge.kt
+++ b/src/main/kotlin/io/vlang/lsp/Lsp4ijBridge.kt
@@ -1,0 +1,32 @@
+package io.vlang.lsp
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry
+
+/**
+ * LSP4IJ-aware bridge. Loaded only when the LSP4IJ plugin (com.redhat.devtools.lsp4ij)
+ * is installed. Registered via vlang-lsp4ij.xml as a service override.
+ *
+ * Uses [LanguageServersRegistry.isFileSupported] which is synchronous and performs
+ * no network I/O — it checks only the in-memory registry of configured servers.
+ */
+class Lsp4ijBridge : VlangLspBridge {
+    override fun isActiveForFile(file: VirtualFile, project: Project): Boolean {
+        return try {
+            val active = LanguageServersRegistry.getInstance().isFileSupported(file, project)
+            if (active) {
+                LOG.debug("V language server detected for ${file.name} — duplicate feature suppression is available")
+            }
+            active
+        } catch (e: Exception) {
+            LOG.warn("LSP4IJ bridge: unexpected error checking language server status", e)
+            false
+        }
+    }
+
+    companion object {
+        private val LOG = logger<Lsp4ijBridge>()
+    }
+}

--- a/src/main/kotlin/io/vlang/lsp/NoOpLspBridge.kt
+++ b/src/main/kotlin/io/vlang/lsp/NoOpLspBridge.kt
@@ -1,0 +1,12 @@
+package io.vlang.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Default bridge used when LSP4IJ is not installed.
+ * Always reports no active language server.
+ */
+class NoOpLspBridge : VlangLspBridge {
+    override fun isActiveForFile(file: VirtualFile, project: Project) = false
+}

--- a/src/main/kotlin/io/vlang/lsp/VlangLspBridge.kt
+++ b/src/main/kotlin/io/vlang/lsp/VlangLspBridge.kt
@@ -1,0 +1,15 @@
+package io.vlang.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Detects whether a V language server (via LSP4IJ) is active for a given file.
+ *
+ * The default implementation [NoOpLspBridge] always returns false.
+ * When LSP4IJ is installed, [Lsp4ijBridge] is loaded via the optional dependency
+ * declared in vlang-lsp4ij.xml and overrides this service.
+ */
+interface VlangLspBridge {
+    fun isActiveForFile(file: VirtualFile, project: Project): Boolean
+}

--- a/src/main/kotlin/io/vlang/lsp/VlangLspSettings.kt
+++ b/src/main/kotlin/io/vlang/lsp/VlangLspSettings.kt
@@ -1,0 +1,29 @@
+package io.vlang.lsp
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "VlangLspSettings",
+    storages = [Storage("VlangLsp.xml")]
+)
+class VlangLspSettings : PersistentStateComponent<VlangLspSettings?> {
+    companion object {
+        fun getInstance() = service<VlangLspSettings>()
+    }
+
+    var suppressWhenLspActive: Boolean = true
+    var suppressInlayHints: Boolean = true
+    var suppressSemanticHighlighting: Boolean = true
+    var suppressDiagnostics: Boolean = true
+    var suppressCompletion: Boolean = false
+
+    override fun getState() = this
+
+    override fun loadState(state: VlangLspSettings) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+}

--- a/src/main/kotlin/io/vlang/lsp/VlangLspStatusAction.kt
+++ b/src/main/kotlin/io/vlang/lsp/VlangLspStatusAction.kt
@@ -1,0 +1,37 @@
+package io.vlang.lsp
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.FileEditorManager
+
+/**
+ * Diagnostic action: reports whether the V language server is currently detected
+ * for the file open in the editor. Accessible via Help menu or Find Action.
+ */
+class VlangLspStatusAction : AnAction("Check V Language Server Status") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val file = FileEditorManager.getInstance(project).selectedEditor?.file
+
+        val bridge = project.service<VlangLspBridge>()
+        val bridgeClass = bridge::class.simpleName
+
+        val status = when {
+            file == null -> "No file open in editor.\nBridge: $bridgeClass"
+            bridge.isActiveForFile(file, project) ->
+                "LSP ACTIVE — a V language server is registered for '${file.name}'.\n" +
+                "Bridge: $bridgeClass"
+            else ->
+                "LSP NOT ACTIVE — no V language server detected for '${file.name}'.\n" +
+                "Bridge: $bridgeClass"
+        }
+
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("V Plugin")
+            .createNotification("V Language Server Detection", status, NotificationType.INFORMATION)
+            .notify(project)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,7 @@ Discord Server: <a href="https://discord.gg/vlang">https://discord.gg/vlang</a><
     <depends optional="true" config-file="cidr-debugger.xml">com.intellij.modules.cidr.debugger</depends>
     <depends optional="true" config-file="idea-plugin.xml">com.intellij.java</depends>
     <depends optional="true" config-file="native-debug-support.xml">com.intellij.nativeDebug</depends>
+    <depends optional="true" config-file="vlang-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
 
     <xi:include href="/META-INF/inspections.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/intentions.xml" xpointer="xpointer(/idea-plugin/*)"/>
@@ -209,7 +210,13 @@ Discord Server: <a href="https://discord.gg/vlang">https://discord.gg/vlang</a><
                                  instance="io.vlang.configurations.VlangDebuggerSettingsConfigurable"
                                  id="io.vlang.configurations.VlangDebuggerSettingsConfigurable"
                                  dynamic="true" displayName="Debugger"/>
+        <applicationConfigurable parentId="MainVlangSettings"
+                                 instance="io.vlang.configurations.VlangLspSettingsConfigurable"
+                                 id="io.vlang.configurations.VlangLspSettingsConfigurable"
+                                 dynamic="true" displayName="Language Server (LSP4IJ)"/>
 
+        <projectService serviceInterface="io.vlang.lsp.VlangLspBridge"
+                        serviceImplementation="io.vlang.lsp.NoOpLspBridge"/>
         <projectService serviceImplementation="io.vlang.configurations.VlangProjectStructureState"/>
         <projectService serviceImplementation="io.vlang.configurations.VlangFmtSettingsState"/>
         <projectService serviceImplementation="io.vlang.lang.psi.VlangStubsManager"/>
@@ -244,6 +251,7 @@ Discord Server: <a href="https://discord.gg/vlang">https://discord.gg/vlang</a><
         <console.folding implementation="io.vlang.ide.run.VlangConsoleFolding"/>
         <consoleFilterProvider implementation="io.vlang.ide.run.VlangConsoleFilterProvider"/>
         <applicationService serviceImplementation="io.vlang.debugger.lang.VlangDebuggerState"/>
+        <applicationService serviceImplementation="io.vlang.lsp.VlangLspSettings"/>
         <runLineMarkerContributor id="VlangRunLineMarkerProvider" language="vlang"
                                   implementationClass="io.vlang.ide.run.VlangRunLineMarkerProvider"/>
         <!-- endregion Run V Configuration -->
@@ -364,6 +372,9 @@ Discord Server: <a href="https://discord.gg/vlang">https://discord.gg/vlang</a><
     <actions>
         <action id="vlang.new.file" class="io.vlang.ide.actions.CreateVlangFileAction">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+        </action>
+        <action id="vlang.lsp.status" class="io.vlang.lsp.VlangLspStatusAction">
+            <add-to-group group-id="HelpMenu" anchor="last"/>
         </action>
     </actions>
 

--- a/src/main/resources/META-INF/vlang-lsp4ij.xml
+++ b/src/main/resources/META-INF/vlang-lsp4ij.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceInterface="io.vlang.lsp.VlangLspBridge"
+                        serviceImplementation="io.vlang.lsp.Lsp4ijBridge"
+                        overrides="true"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
## Summary

- Adds optional LSP4IJ dependency that detects when a V language server is configured and suppresses native plugin features that would appear twice: inlay hints, semantic highlighting, diagnostics, and (opt-in) code completion
- Introduces `VlangLspBridge` project service with `NoOpLspBridge` (default) and `Lsp4ijBridge` (loaded via `vlang-lsp4ij.xml` when LSP4IJ is installed), using `LanguageServersRegistry.isFileSupported()` — synchronous, no I/O
- Adds `VlangLspSettings` application service and settings UI under **Settings → Languages & Frameworks → V → Language Server (LSP4IJ)** with per-feature toggles (hints/highlighting/diagnostics on by default, completion off)
- Also suppresses inlay hints that would render the type name as `"unknown"` (unresolvable types in composite types like `map[string]unknown`)

## Test plan

- [ ] With LSP4IJ absent: all features work normally, no-op bridge returns false
- [ ] With LSP4IJ installed and a V language server configured: inlay hints, semantic highlighting, and diagnostics are suppressed; completion is not suppressed by default
- [ ] Settings page visible at **Settings → Languages & Frameworks → V → Language Server (LSP4IJ)**
- [ ] Toggling individual checkboxes takes effect immediately on the next editor pass
- [ ] Unchecking the master checkbox re-enables all native features regardless of sub-checkbox state
- [ ] Variables with unresolvable types (e.g. `map[string]unknown`) no longer show an inlay hint

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)