### PR TITLE
Fix debug runner compatibility with CLion split debugger mode

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.10.5"
+intelliJPlatform = "2.15.0"
 kotlin = "2.2.21"
 kover = "0.9.3"
 qodana = "2025.2.2"

--- a/src/main/kotlin/io/vlang/debugger/runconfig/VlangDebugRunner.kt
+++ b/src/main/kotlin/io/vlang/debugger/runconfig/VlangDebugRunner.kt
@@ -77,7 +77,7 @@ open class VlangDebugRunner : AsyncProgramRunner<RunnerSettings>() {
     private fun showRunContent(
         environment: ExecutionEnvironment,
         runExecutable: GeneralCommandLine,
-    ): RunContentDescriptor = VlangDebugRunnerUtils.showRunContent(environment, runExecutable)
+    ): RunContentDescriptor? = VlangDebugRunnerUtils.showRunContent(environment, runExecutable)
 
     companion object {
         const val RUNNER_ID: String = "VlangDebugRunner"

--- a/src/main/kotlin/io/vlang/debugger/runconfig/VlangDebugRunnerUtils.kt
+++ b/src/main/kotlin/io/vlang/debugger/runconfig/VlangDebugRunnerUtils.kt
@@ -15,7 +15,7 @@ object VlangDebugRunnerUtils {
     fun showRunContent(
         environment: ExecutionEnvironment,
         runExecutable: GeneralCommandLine,
-    ): RunContentDescriptor {
+    ): RunContentDescriptor? {
         val runParameters = VlangDebugRunParameters(
             environment.project,
             runExecutable,
@@ -26,7 +26,7 @@ object VlangDebugRunnerUtils {
         val searchScope = ExecutionSearchScopes.executionScope(project, environment.runProfile)
         val consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(project, searchScope)
 
-        return XDebuggerManager.getInstance(environment.project)
+        XDebuggerManager.getInstance(environment.project)
             .startSession(environment, object : XDebugProcessStarter() {
                 override fun start(session: XDebugSession): XDebugProcess =
                     VlangLocalDebugProcess(runParameters, session, consoleBuilder).apply {
@@ -34,6 +34,6 @@ object VlangDebugRunnerUtils {
                         start()
                     }
             })
-            .runContentDescriptor
+        return null
     }
 }

--- a/src/main/kotlin/io/vlang/lang/VlangFileElementType.kt
+++ b/src/main/kotlin/io/vlang/lang/VlangFileElementType.kt
@@ -49,6 +49,6 @@ class VlangFileElementType : IStubFileElementType<VlangFileStub>("VLANG_FILE", V
 
     companion object {
         val INSTANCE = VlangFileElementType()
-        const val VERSION = 95
+        const val VERSION = 96
     }
 }


### PR DESCRIPTION
## Summary

- `XDebugSession.getRunContentDescriptor()` is deprecated and throws an error in newer CLion builds when split debugger mode is active
- `XDebuggerManager.startSession()` already registers the session internally; the runner no longer needs to extract and return the descriptor
- Changed `showRunContent` return type to `RunContentDescriptor?` and return `null` instead of accessing the deprecated property

## Test plan

- [ ] Launch a V debug run configuration and verify the debugger starts and the debug tool window opens normally
- [ ] Verify no `[Split debugger] RunContentDescriptor should not be used in split mode` error in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)